### PR TITLE
Add logging of intermediate LLM responses

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,3 +15,5 @@ dotnet run --project src/ConsensusApp/ConsensusApp -- "your question here"
 ```
 
 The program will prompt you for models and your OpenRouter API key if not provided in the `OPENROUTER_API_KEY` environment variable.
+
+You can optionally create a markdown log file of each model's response. When prompted, choose `Minimal` to log short summaries of each model's changes or `Full` to store every response separated by `-----------` lines.

--- a/src/ConsensusApp/ConsensusApp/Logging.cs
+++ b/src/ConsensusApp/ConsensusApp/Logging.cs
@@ -1,0 +1,8 @@
+namespace ConsensusApp;
+
+internal enum LogLevel
+{
+    None,
+    Minimal,
+    Full
+}


### PR DESCRIPTION
## Summary
- add LogLevel enum for controlling logging
- prompt for logging mode in console app
- log each model's response to Markdown file
- return log path to the user
- document logging feature

## Testing
- `dotnet restore`
- `dotnet build --no-restore`

------
https://chatgpt.com/codex/tasks/task_e_6844dabb1218832fb572da1640fa86c1