### PR TITLE
Introduce ILogger wrapper and console interface

### DIFF
--- a/src/ConsensusApp/ConsensusApp/ConsensusApp.csproj
+++ b/src/ConsensusApp/ConsensusApp/ConsensusApp.csproj
@@ -12,6 +12,7 @@
     <PackageReference Include="OpenAI.GPT3" Version="1.0.3" />
     <PackageReference Include="Spectre.Console" Version="0.50.0" />
     <PackageReference Include="Spectre.Console.Cli" Version="0.50.0" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="9.0.0" />
   </ItemGroup>
 
 </Project>

--- a/src/ConsensusApp/ConsensusApp/ConsensusProcessor.cs
+++ b/src/ConsensusApp/ConsensusApp/ConsensusProcessor.cs
@@ -11,10 +11,12 @@ namespace ConsensusApp;
 internal sealed class ConsensusProcessor
 {
     private readonly OpenRouterClient _client;
+    private readonly IConsoleService _console;
 
-    public ConsensusProcessor(OpenRouterClient client)
+    public ConsensusProcessor(OpenRouterClient client, IConsoleService console)
     {
         _client = client;
+        _console = console;
     }
 
     public async Task<ConsensusResult> RunAsync(string prompt, IReadOnlyList<string> models, LogLevel logLevel)
@@ -26,8 +28,7 @@ internal sealed class ConsensusProcessor
 
         foreach (var model in models)
         {
-            await AnsiConsole.Status()
-                .StartAsync($"Querying [green]{model}[/]", async _ =>
+            await _console.StatusAsync("Querying {0}", model, async () =>
                 {
                     List<ChatMessage> messages;
                     if (answer == prompt)
@@ -96,8 +97,7 @@ internal sealed class ConsensusProcessor
     private async Task<string> SummarizeAsync(string model, string answer)
     {
         string summary = string.Empty;
-        await AnsiConsole.Status()
-            .StartAsync("Summarizing final answer", async _ =>
+        await _console.StatusAsync("Summarizing final answer", async () =>
             {
                 summary = await _client.QueryAsync(model, new ChatMessage[]
                 {
@@ -112,8 +112,7 @@ internal sealed class ConsensusProcessor
     private async Task<string> SummarizeChangesAsync(string model, string answer)
     {
         string summary = string.Empty;
-        await AnsiConsole.Status()
-            .StartAsync($"Summarizing response from {model}", async _ =>
+        await _console.StatusAsync("Summarizing response from {0}", model, async () =>
             {
                 summary = await _client.QueryAsync(model, new ChatMessage[]
                 {

--- a/src/ConsensusApp/ConsensusApp/IConsoleService.cs
+++ b/src/ConsensusApp/ConsensusApp/IConsoleService.cs
@@ -1,0 +1,12 @@
+namespace ConsensusApp;
+
+using Spectre.Console;
+
+internal interface IConsoleService
+{
+    T Ask<T>(string prompt);
+    T Prompt<T>(IPrompt<T> prompt);
+    void MarkupLine(string markup);
+    Task StatusAsync(string status, Func<Task> action);
+    Task StatusAsync<T>(string statusFormat, T arg, Func<Task> action);
+}

--- a/src/ConsensusApp/ConsensusApp/Logger.cs
+++ b/src/ConsensusApp/ConsensusApp/Logger.cs
@@ -1,0 +1,54 @@
+using Microsoft.Extensions.Logging;
+using System.Collections.Generic;
+
+namespace ConsensusApp;
+
+/// <summary>
+/// Simple <see cref="ILogger"/> implementation that writes markup
+/// strings to <see cref="Spectre.Console.AnsiConsole"/>.
+/// </summary>
+internal sealed class AnsiConsoleLogger<T> : ILogger<T>
+{
+    private sealed class NullScope : IDisposable
+    {
+        public static NullScope Instance { get; } = new();
+        public void Dispose() { }
+    }
+
+    public IDisposable BeginScope<TState>(TState state) => NullScope.Instance;
+
+    public bool IsEnabled(Microsoft.Extensions.Logging.LogLevel logLevel) => true;
+
+    public void Log<TState>(Microsoft.Extensions.Logging.LogLevel logLevel, EventId eventId, TState state, Exception? exception, Func<TState, Exception?, string> formatter)
+    {
+        var message = formatter(state, exception);
+
+        if (state is IEnumerable<KeyValuePair<string, object>> values)
+        {
+            foreach (var kvp in values)
+            {
+                if (kvp.Key == "{OriginalFormat}")
+                    continue;
+
+                var valueText = kvp.Value?.ToString() ?? string.Empty;
+                message = message.Replace(valueText, $"[green]{valueText}[/]");
+            }
+        }
+
+        var color = logLevel switch
+        {
+            Microsoft.Extensions.Logging.LogLevel.Error => "red",
+            Microsoft.Extensions.Logging.LogLevel.Warning => "yellow",
+            _ => null
+        };
+
+        if (color is not null)
+        {
+            Spectre.Console.AnsiConsole.MarkupLine($"[{color}]{message}[/]");
+        }
+        else
+        {
+            Spectre.Console.AnsiConsole.MarkupLine(message);
+        }
+    }
+}

--- a/src/ConsensusApp/ConsensusApp/SpectreConsoleService.cs
+++ b/src/ConsensusApp/ConsensusApp/SpectreConsoleService.cs
@@ -1,0 +1,20 @@
+namespace ConsensusApp;
+
+using Spectre.Console;
+
+internal sealed class SpectreConsoleService : IConsoleService
+{
+    public T Ask<T>(string prompt) => AnsiConsole.Ask<T>(prompt);
+
+    public T Prompt<T>(IPrompt<T> prompt) => AnsiConsole.Prompt(prompt);
+
+    public void MarkupLine(string markup) => AnsiConsole.MarkupLine(markup);
+
+    public Task StatusAsync(string status, Func<Task> action)
+        => AnsiConsole.Status().StartAsync(status, _ => action());
+
+    public Task StatusAsync<T>(string statusFormat, T arg, Func<Task> action)
+        => AnsiConsole.Status().StartAsync(
+            string.Format(statusFormat, $"[green]{arg}[/]"),
+            _ => action());
+}


### PR DESCRIPTION
## Summary
- add `StatusAsync<T>` to `IConsoleService` for coloured status messages
- highlight parameters within `AnsiConsoleLogger<T>` based on log level
- remove inline markup from `Program` and `ConsensusProcessor`

## Testing
- `dotnet restore`
- `dotnet build --no-restore`

------
https://chatgpt.com/codex/tasks/task_e_684546463c68832fb8181e2326e8394a