### PR TITLE
Add optional timestamped file names

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,4 +17,5 @@ dotnet run --project src/ConsensusApp/ConsensusApp -- "your question here"
 The program will prompt you for models and your OpenRouter API key if not provided in the `OPENROUTER_API_KEY` environment variable.
 
 You can optionally create a markdown log file of each model's response. When prompted, choose `Minimal` to log short summaries of each model's changes or `Full` to store every response separated by `-----------` lines. At the end of the log file each model's *Summary for Consensus* section is also collected for quick reference.
+By default the log and response files use the first ten characters of the prompt for their names and are overwritten on each run. Set the `CONSENSUS_UNIQUE_FILES` environment variable to create new files with a timestamp instead.
 The system prompts used for each model are stored as text files in `Resources` and embedded in the application.


### PR DESCRIPTION
## Summary
- add `CONSENSUS_UNIQUE_FILES` environment variable to control file naming
- default names now use sanitized first 10 prompt characters
- document the new behaviour in README

## Testing
- `dotnet build`

------
https://chatgpt.com/codex/tasks/task_e_68456c014750832f8a53bdd4f94d5e4b