### PR TITLE
Fix nested Spectre.Console progress displays

### DIFF
--- a/src/ConsensusApp/ConsensusApp/ModelQueue.cs
+++ b/src/ConsensusApp/ConsensusApp/ModelQueue.cs
@@ -58,35 +58,35 @@ internal sealed class ModelQueue
 
             answer = await _client.QueryAsync(model, messages);
             summaryForConsensus = ExtractConsensusSummary(answer);
-
-            if (logBuilder is not null)
-            {
-                if (logLevel == LogLevel.Full)
-                {
-                    logBuilder.AppendLine($"### {model}");
-                    logBuilder.AppendLine(answer);
-                    logBuilder.AppendLine();
-                    logBuilder.AppendLine("-----------");
-                    logBuilder.AppendLine();
-                }
-                else if (logLevel == LogLevel.Minimal)
-                {
-                    string summary;
-                    if (previousModel == string.Empty)
-                    {
-                        summary = "Initial answer generated.";
-                    }
-                    else
-                    {
-                        summary = await summarizeChanges(model, answer);
-                    }
-
-                    logBuilder.AppendLine($"### {model}");
-                    logBuilder.AppendLine(summary.Trim());
-                    logBuilder.AppendLine();
-                }
-            }
         });
+
+        if (logBuilder is not null)
+        {
+            if (logLevel == LogLevel.Full)
+            {
+                logBuilder.AppendLine($"### {model}");
+                logBuilder.AppendLine(answer);
+                logBuilder.AppendLine();
+                logBuilder.AppendLine("-----------");
+                logBuilder.AppendLine();
+            }
+            else if (logLevel == LogLevel.Minimal)
+            {
+                string summary;
+                if (previousModel == string.Empty)
+                {
+                    summary = "Initial answer generated.";
+                }
+                else
+                {
+                    summary = await summarizeChanges(model, answer);
+                }
+
+                logBuilder.AppendLine($"### {model}");
+                logBuilder.AppendLine(summary.Trim());
+                logBuilder.AppendLine();
+            }
+        }
 
         return new ModelResult(model, answer, summaryForConsensus);
     }


### PR DESCRIPTION
## Summary
- avoid nested progress displays by moving logging out of the status block

## Testing
- `dotnet build`

------
https://chatgpt.com/codex/tasks/task_e_6845742de2fc832f9c95cb4c0dc236c3