### PR TITLE
Load change summary prompt from resource

### DIFF
--- a/src/ConsensusApp/ConsensusApp/Program.cs
+++ b/src/ConsensusApp/ConsensusApp/Program.cs
@@ -16,6 +16,7 @@ public sealed class ConsensusCommand : AsyncCommand<ConsensusCommand.Settings>
     {
         var console = new SpectreConsoleService();
         ILogger<ConsensusCommand> logger = new AnsiConsoleLogger<ConsensusCommand>();
+        ILogger<ConsensusProcessor> processorLogger = new AnsiConsoleLogger<ConsensusProcessor>();
 
         var prompt = settings.Prompt ?? console.Ask<string>("Enter your question:");
 
@@ -57,7 +58,7 @@ public sealed class ConsensusCommand : AsyncCommand<ConsensusCommand.Settings>
         };
 
         var client = new OpenRouterClient(apiKey);
-        var processor = new ConsensusProcessor(client, console);
+        var processor = new ConsensusProcessor(client, console, processorLogger);
 
         var result = await processor.RunAsync(prompt, models, logLevel);
 

--- a/src/ConsensusApp/ConsensusApp/Prompts.cs
+++ b/src/ConsensusApp/ConsensusApp/Prompts.cs
@@ -1,0 +1,11 @@
+namespace ConsensusApp;
+
+internal static class Prompts
+{
+    public static readonly string InitialSystemPrompt =
+        ResourceHelper.GetString("ConsensusApp.Resources.InitialSystemPrompt.txt");
+    public static readonly string FollowupSystemPrompt =
+        ResourceHelper.GetString("ConsensusApp.Resources.FollowupSystemPrompt.txt");
+    public static readonly string ChangeSummarySystemPrompt =
+        ResourceHelper.GetString("ConsensusApp.Resources.ChangeSummarySystemPrompt.txt");
+}

--- a/src/ConsensusApp/ConsensusApp/Resources/ChangeSummarySystemPrompt.txt
+++ b/src/ConsensusApp/ConsensusApp/Resources/ChangeSummarySystemPrompt.txt
@@ -1,0 +1,1 @@
+Summarize the changes you made compared to the previous answer in one sentence. If nothing changed, reply with 'No changes.'


### PR DESCRIPTION
## Summary
- centralize prompt resources in `Prompts` static class
- use `Prompts` in `ModelQueue` and `ConsensusProcessor`
- log each LLM's change summary as before

## Testing
- `dotnet build`


------
https://chatgpt.com/codex/tasks/task_e_68457b1c5390832fb8d9fdb664d05a8e