### PR TITLE
Lowercase output filenames

### DIFF
--- a/src/ConsensusApp/ConsensusApp/ConsensusProcessor.cs
+++ b/src/ConsensusApp/ConsensusApp/ConsensusProcessor.cs
@@ -51,7 +51,7 @@ internal sealed class ConsensusProcessor
         var uniqueFiles = Environment.GetEnvironmentVariable("CONSENSUS_UNIQUE_FILES") is not null;
         var baseName = uniqueFiles
             ? DateTime.Now.ToString("yyyyMMddHHmmss")
-            : SanitizeFileName(prompt);
+            : SanitizeFileName(prompt).ToLowerInvariant();
 
         if (logBuilder is not null)
         {


### PR DESCRIPTION
## Summary
- ensure output files use lowercase prompt names

## Testing
- `dotnet build`

------
https://chatgpt.com/codex/tasks/task_e_68458789817c832fa6499b746305d952