### PR TITLE
Improve summary layout in logger

### DIFF
--- a/src/ConsensusApp/ConsensusApp/Program.cs
+++ b/src/ConsensusApp/ConsensusApp/Program.cs
@@ -62,8 +62,8 @@ public sealed class ConsensusCommand : AsyncCommand<ConsensusCommand.Settings>
 
         var result = await processor.RunAsync(prompt, models, logLevel);
 
-        logger.LogInformation("Summary: {Summary}", result.Summary);
-        logger.LogInformation("Full answer written to {Path}", result.Path);
+        logger.LogInformation("\n[bold]Summary:[/]\n{Summary}\n", result.Summary);
+        logger.LogInformation("[bold]Full answer written to:[/]\n{Path}\n", result.Path);
         if (result.LogPath is not null)
         {
             logger.LogInformation("Log written to {Path}", result.LogPath);


### PR DESCRIPTION
## Summary
- improve layout of summary and file path log messages

## Testing
- `dotnet restore`
- `dotnet build --no-restore`


------
https://chatgpt.com/codex/tasks/task_e_6845962737f8832fb36c8af94f4d6dc5