### PR TITLE
Fix empty value replacement in logger

### DIFF
--- a/src/ConsensusApp/ConsensusApp/AnsiConsoleLogger.cs
+++ b/src/ConsensusApp/ConsensusApp/AnsiConsoleLogger.cs
@@ -30,7 +30,11 @@ internal sealed class AnsiConsoleLogger<T> : ILogger<T>
                 if (kvp.Key == "{OriginalFormat}")
                     continue;
 
-                var valueText = kvp.Value?.ToString() ?? string.Empty;
+                var valueText = kvp.Value?.ToString();
+
+                if (string.IsNullOrEmpty(valueText))
+                    continue;
+
                 message = message.Replace(valueText, $"[green]{valueText}[/]");
             }
         }


### PR DESCRIPTION
## Summary
- guard against empty key/value pairs when decorating console logs

## Testing
- `dotnet build`


------
https://chatgpt.com/codex/tasks/task_e_6845e0a6bfe8832f8e739d751874b01b