### PR TITLE
Fix summary display and logging

### DIFF
--- a/src/ConsensusApp/ConsensusApp/ConsensusProcessor.cs
+++ b/src/ConsensusApp/ConsensusApp/ConsensusProcessor.cs
@@ -50,7 +50,8 @@ internal sealed class ConsensusProcessor
             if (firstModel)
             {
                 _console.MarkupLine("Initial answer generated.");
-                _logger.LogInformation("\n[bold]{Model} answer summary:[/]\n- {Summary}\n", result.Model, result.ChangeSummary);
+                var initialSummary = result.InitialSummary ?? ResponseParser.GetInitialResponseSummary(result.Answer);
+                _logger.LogInformation("\n[bold]{Model} answer summary:[/]\n- {Summary}\n", result.Model, initialSummary);
             }
             else
             {
@@ -102,7 +103,7 @@ internal sealed class ConsensusProcessor
                 });
             });
 
-        return summary.Split('\n').FirstOrDefault() ?? string.Empty;
+        return summary.Trim();
     }
 
     private async Task<string> GenerateFinalChangesSummaryAsync(string model, IEnumerable<ModelResult> results)

--- a/src/ConsensusApp/ConsensusApp/ModelQueue.cs
+++ b/src/ConsensusApp/ConsensusApp/ModelQueue.cs
@@ -56,8 +56,10 @@ internal sealed class ModelQueue
         });
 
         string changeSummary;
+        string? initialSummary = null;
         if (previousModel == string.Empty)
         {
+            initialSummary = ResponseParser.GetInitialResponseSummary(answer);
             changeSummary = ResponseParser.GetChangesSummary(answer);
             if (string.IsNullOrEmpty(changeSummary))
             {
@@ -80,13 +82,19 @@ internal sealed class ModelQueue
                 logBuilder.AppendLine();
             }
 
+            if (!string.IsNullOrEmpty(initialSummary))
+            {
+                logBuilder.AppendLine(initialSummary.Trim());
+                logBuilder.AppendLine();
+            }
+
             logBuilder.AppendLine(changeSummary.Trim());
             logBuilder.AppendLine();
         }
 
-        return new ModelResult(model, answer, changeSummary.Trim());
+        return new ModelResult(model, answer, changeSummary.Trim(), initialSummary?.Trim());
     }
 
 }
 
-internal sealed record ModelResult(string Model, string Answer, string ChangeSummary);
+internal sealed record ModelResult(string Model, string Answer, string ChangeSummary, string? InitialSummary);


### PR DESCRIPTION
## Summary
- return full change summaries instead of first line
- capture the initial answer summary for the first model
- include initial summary in log files
- show the initial summary in console output

## Testing
- `dotnet build`

------
https://chatgpt.com/codex/tasks/task_e_6845f531bf8c832fa2b4ea1dd0ef4bf9