### PR TITLE
Add previous answer to change summary

### DIFF
--- a/src/ConsensusApp/ConsensusApp/ConsensusApp.csproj
+++ b/src/ConsensusApp/ConsensusApp/ConsensusApp.csproj
@@ -17,6 +17,12 @@
   </ItemGroup>
 
   <ItemGroup>
+    <AssemblyAttribute Include="System.Runtime.CompilerServices.InternalsVisibleTo">
+      <_Parameter1>ConsensusApp.Tests</_Parameter1>
+    </AssemblyAttribute>
+  </ItemGroup>
+
+  <ItemGroup>
     <EmbeddedResource Include="Resources\*.txt" />
   </ItemGroup>
 

--- a/src/ConsensusApp/ConsensusApp/ConsensusProcessor.cs
+++ b/src/ConsensusApp/ConsensusApp/ConsensusProcessor.cs
@@ -91,7 +91,7 @@ internal sealed class ConsensusProcessor
         return new(path, summary, logPath == string.Empty ? null : logPath);
     }
 
-    private async Task<string> SummarizeChangesAsync(string model, string answer)
+    private async Task<string> SummarizeChangesAsync(string model, string answer, string previousAnswer)
     {
         string summary = string.Empty;
         await _console.StatusAsync("Summarizing response from {0}", model, async () =>
@@ -99,7 +99,8 @@ internal sealed class ConsensusProcessor
                 summary = await _client.QueryAsync(model, new ChatMessage[]
                 {
                     ChatMessage.CreateSystemMessage(Prompts.ChangeSummarySystemPrompt),
-                    ChatMessage.CreateUserMessage(answer)
+                    ChatMessage.CreateUserMessage(ResponseParser.GetRevisedAnswer(previousAnswer)),
+                    ChatMessage.CreateAssistantMessage(ResponseParser.GetRevisedAnswer(answer))
                 });
             });
 

--- a/src/ConsensusApp/ConsensusApp/IChatClient.cs
+++ b/src/ConsensusApp/ConsensusApp/IChatClient.cs
@@ -1,0 +1,10 @@
+namespace ConsensusApp;
+
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using OpenAI.Chat;
+
+internal interface IChatClient
+{
+    Task<string> CompleteChatAsync(string model, IEnumerable<ChatMessage> messages);
+}

--- a/src/ConsensusApp/ConsensusApp/ModelQueue.cs
+++ b/src/ConsensusApp/ConsensusApp/ModelQueue.cs
@@ -27,10 +27,11 @@ internal sealed class ModelQueue
         string previousModel,
         LogLevel logLevel,
         StringBuilder? logBuilder,
-        Func<string, string, Task<string>> summarizeChanges)
+        Func<string, string, string, Task<string>> summarizeChanges)
     {
         var model = _models.Dequeue();
 
+        string previousAnswer = answer;
         await _console.StatusAsync("Querying {0}", model, async () =>
         {
             List<ChatMessage> messages;
@@ -68,7 +69,7 @@ internal sealed class ModelQueue
         }
         else
         {
-            changeSummary = await summarizeChanges(model, answer);
+            changeSummary = await summarizeChanges(model, answer, previousAnswer);
         }
 
         if (logBuilder is not null)

--- a/src/ConsensusApp/ConsensusApp/OpenAIChatClient.cs
+++ b/src/ConsensusApp/ConsensusApp/OpenAIChatClient.cs
@@ -1,0 +1,28 @@
+namespace ConsensusApp;
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using OpenAI;
+using OpenAI.Chat;
+using System.ClientModel;
+
+internal sealed class OpenAIChatClient : IChatClient
+{
+    private readonly string _apiKey;
+    private readonly OpenAIClientOptions _options = new() { Endpoint = new Uri("https://openrouter.ai/api/v1") };
+
+    public OpenAIChatClient(string apiKey)
+    {
+        _apiKey = apiKey;
+    }
+
+    public async Task<string> CompleteChatAsync(string model, IEnumerable<ChatMessage> messages)
+    {
+        var credential = new ApiKeyCredential(_apiKey);
+        var client = new ChatClient(model, credential, _options);
+        var completion = await client.CompleteChatAsync(messages);
+        return string.Join("\n", completion.Value.Content.Select(p => p.Text));
+    }
+}

--- a/src/ConsensusApp/ConsensusApp/OpenRouterClient.cs
+++ b/src/ConsensusApp/ConsensusApp/OpenRouterClient.cs
@@ -1,28 +1,22 @@
-using System;
 using System.Collections.Generic;
-using System.Linq;
 using System.Threading.Tasks;
-using OpenAI;
 using OpenAI.Chat;
-using System.ClientModel;
 
 namespace ConsensusApp;
 
 internal sealed class OpenRouterClient
 {
-    private readonly string _apiKey;
-    private readonly OpenAIClientOptions _options = new() { Endpoint = new Uri("https://openrouter.ai/api/v1") };
+    private readonly IChatClient _client;
 
-    public OpenRouterClient(string apiKey)
+    public OpenRouterClient(string apiKey) : this(new OpenAIChatClient(apiKey))
     {
-        _apiKey = apiKey;
     }
 
-    public async Task<string> QueryAsync(string model, IEnumerable<ChatMessage> messages)
+    internal OpenRouterClient(IChatClient client)
     {
-        var credential = new ApiKeyCredential(_apiKey);
-        var client = new ChatClient(model, credential, _options);
-        var completion = await client.CompleteChatAsync(messages);
-        return string.Join("\n", completion.Value.Content.Select(p => p.Text));
+        _client = client;
     }
+
+    public Task<string> QueryAsync(string model, IEnumerable<ChatMessage> messages)
+        => _client.CompleteChatAsync(model, messages);
 }

--- a/tests/ConsensusApp.Tests/ConsensusApp.Tests.csproj
+++ b/tests/ConsensusApp.Tests/ConsensusApp.Tests.csproj
@@ -1,0 +1,25 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="coverlet.collector" Version="6.0.2" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
+    <PackageReference Include="xunit" Version="2.9.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="../../src/ConsensusApp/ConsensusApp/ConsensusApp.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Using Include="Xunit" />
+  </ItemGroup>
+
+</Project>

--- a/tests/ConsensusApp.Tests/ConsensusAppProcessorTests.cs
+++ b/tests/ConsensusApp.Tests/ConsensusAppProcessorTests.cs
@@ -1,0 +1,125 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Logging.Abstractions;
+using OpenAI.Chat;
+using Spectre.Console;
+using Xunit;
+
+namespace ConsensusApp.Tests;
+
+public class ConsensusProcessorTests
+{
+    [Fact]
+    public async Task RunAsync_WritesExpectedFiles()
+    {
+        var responses = new Queue<string>(new[]
+        {
+            "<InitialResponse>Answer1</InitialResponse><ChangesSummary>No changes as it's the first response.</ChangesSummary><InitialResponseSummary>Summary1</InitialResponseSummary>",
+            "<ChangesSummary>Final summary</ChangesSummary>"
+        });
+
+        var client = new ConsensusApp.OpenRouterClient(new StubChatClient(responses));
+        var console = new StubConsoleService();
+        var processor = new ConsensusApp.ConsensusProcessor(client, console, NullLogger<ConsensusApp.ConsensusProcessor>.Instance);
+
+        var tempDir = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName());
+        Directory.CreateDirectory(tempDir);
+        var originalDir = Directory.GetCurrentDirectory();
+        Directory.SetCurrentDirectory(tempDir);
+
+        try
+        {
+            var result = await processor.RunAsync("TestPrompt", new[] { "model1" }, ConsensusApp.LogLevel.Minimal);
+
+            Assert.True(File.Exists(result.Path));
+            Assert.NotNull(result.LogPath);
+            Assert.True(File.Exists(result.LogPath!));
+
+            var answer = File.ReadAllText(result.Path);
+            Assert.Equal("## Answer\n\nAnswer1\n\n## Changes Summary\n\nFinal summary\n", answer);
+
+            var log = File.ReadAllText(result.LogPath!);
+            var expectedLog = "# model1\nSummary1\n\nNo changes as it's the first response.\n\n### Change Summaries\n#### model1\nNo changes as it's the first response.\n\n";
+            Assert.Equal(expectedLog, log);
+        }
+        finally
+        {
+            Directory.SetCurrentDirectory(originalDir);
+            Directory.Delete(tempDir, true);
+        }
+    }
+
+    [Fact]
+    public async Task RunAsync_TwoModels_UsesPreviousAnswerForSummary()
+    {
+        var responses = new Queue<string>(new[]
+        {
+            "<InitialResponse>Answer1</InitialResponse><ChangesSummary>No changes as it's the first response.</ChangesSummary><InitialResponseSummary>Summary1</InitialResponseSummary>",
+            "<RevisedAnswer>Answer2</RevisedAnswer>",
+            "Bullet summary 2",
+            "<ChangesSummary>Final summary</ChangesSummary>"
+        });
+
+        var stub = new StubChatClient(responses);
+        var client = new ConsensusApp.OpenRouterClient(stub);
+        var console = new StubConsoleService();
+        var processor = new ConsensusApp.ConsensusProcessor(client, console, NullLogger<ConsensusApp.ConsensusProcessor>.Instance);
+
+        var tempDir = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName());
+        Directory.CreateDirectory(tempDir);
+        var originalDir = Directory.GetCurrentDirectory();
+        Directory.SetCurrentDirectory(tempDir);
+
+        try
+        {
+            var result = await processor.RunAsync("Prompt", new[] { "model1", "model2" }, ConsensusApp.LogLevel.Minimal);
+
+            Assert.Equal(4, stub.Requests.Count);
+            var summaryCall = stub.Requests[2];
+            Assert.Equal(3, summaryCall.Count);
+            Assert.Contains("Answer1", summaryCall[1].Content.First().Text);
+            Assert.Contains("Answer2", summaryCall[2].Content.First().Text);
+
+            var answer = File.ReadAllText(result.Path);
+            Assert.Equal("## Answer\n\nAnswer2\n\n## Changes Summary\n\nFinal summary\n", answer);
+
+            var log = File.ReadAllText(result.LogPath!);
+            var expectedLog = "# model1\nSummary1\n\nNo changes as it's the first response.\n\n# model2\nBullet summary 2\n\n### Change Summaries\n#### model1\nNo changes as it's the first response.\n\n#### model2\nBullet summary 2\n\n";
+            Assert.Equal(expectedLog, log);
+        }
+        finally
+        {
+            Directory.SetCurrentDirectory(originalDir);
+            Directory.Delete(tempDir, true);
+        }
+    }
+
+    private sealed class StubConsoleService : ConsensusApp.IConsoleService
+    {
+        public T Ask<T>(string prompt) => throw new NotImplementedException();
+        public T Prompt<T>(IPrompt<T> prompt) => throw new NotImplementedException();
+        public void MarkupLine(string markup) { }
+        public Task StatusAsync(string status, Func<Task> action) => action();
+        public Task StatusAsync<T>(string statusFormat, T arg, Func<Task> action) => action();
+    }
+
+    private sealed class StubChatClient : ConsensusApp.IChatClient
+    {
+        private readonly Queue<string> _responses;
+        public List<IReadOnlyList<ChatMessage>> Requests { get; } = new();
+
+        public StubChatClient(Queue<string> responses)
+        {
+            _responses = responses;
+        }
+
+        public Task<string> CompleteChatAsync(string model, IEnumerable<ChatMessage> messages)
+        {
+            Requests.Add(messages.ToList());
+            return Task.FromResult(_responses.Dequeue());
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- include previous answer when generating change summaries
- update `ModelQueue` to pass previous answer
- refine unit tests for multi-model runs and capture chat requests

## Testing
- `dotnet format --no-restore`
- `dotnet test tests/ConsensusApp.Tests/ConsensusApp.Tests.csproj -v minimal`


------
https://chatgpt.com/codex/tasks/task_e_6845fcb6c034832f80d55ab040609be3