### PR TITLE
Add build release workflow

### DIFF
--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -1,0 +1,105 @@
+name: build-and-create-release
+
+on:
+  workflow_dispatch:
+  push:
+    tags:
+      - 'v[0-9]+.[0-9]+.[0-9]+'
+    paths-ignore: 
+      - ".github/**"
+      - ".gitignore"
+      - "README.md"
+      - "LICENSE"
+      - "CHANGELOG.md"
+      - "docs/**"
+      - "gitversion.yml"
+      - ".editorconfig"
+      - ".vs/**"
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+
+    steps:
+    - uses: actions/checkout@v4
+      with:
+        fetch-tags: true
+        fetch-depth: 0
+    
+    - name: Setup .NET
+      uses: actions/setup-dotnet@v4
+      with:
+        dotnet-version: 8.0.x
+
+    - name: Install Git version
+      uses: gittools/actions/gitversion/setup@v3.2.0
+      with:
+        versionSpec: '6.2.0'
+    
+    - name: Get version
+      uses: gittools/actions/gitversion/execute@v3.2.0
+      id: get_version
+        
+    - name: Restore dependencies
+      run: dotnet restore
+      
+    - name: Publish Win x64 exe
+      run: dotnet publish -c Release --os win --arch x64 -p:Version=${{ steps.get_version.outputs.MajorMinorPatch  }}
+
+    - name: Publish Linux x64 exe
+      run: dotnet publish -c Release --os linux --arch x64 -p:Version=${{ steps.get_version.outputs.MajorMinorPatch  }}
+
+    - name: Publish macOS x64 exe
+      run: dotnet publish -c Release --os osx --arch x64 -p:Version=${{ steps.get_version.outputs.MajorMinorPatch  }}
+
+    - name: Upload Win build artifact
+      uses: actions/upload-artifact@v4
+      with:
+        name: win-x64-build-v${{ steps.get_version.outputs.MajorMinorPatch  }}
+        path: '**/bin/Release/net*/win-x64/publish/consensus.exe'
+        if-no-files-found: error
+
+    - name: Upload Linux build artifact
+      uses: actions/upload-artifact@v4
+      with:
+        name: linux-x64-build-v${{ steps.get_version.outputs.MajorMinorPatch  }}
+        path: '**/bin/Release/net*/linux-x64/publish/consensus'
+        if-no-files-found: error
+
+    - name: Upload macOS build artifact
+      uses: actions/upload-artifact@v4
+      with:
+        name: macos-x64-build-v${{ steps.get_version.outputs.MajorMinorPatch  }}
+        path: '**/bin/Release/net*/osx-x64/publish/consensus'
+        if-no-files-found: error
+
+    - name: Create Release
+      id: create_release
+      uses: softprops/action-gh-release@v2
+      with:
+        tag_name: v${{ steps.get_version.outputs.MajorMinorPatch  }}
+        name: Release v${{ steps.get_version.outputs.MajorMinorPatch  }}
+        generate_release_notes: true
+        draft: false
+        prerelease: false
+        make_latest: true
+        files: |
+            **/bin/Release/net*/win-x64/publish/consensus.exe
+            **/bin/Release/net*/linux-x64/publish/consensus
+            **/bin/Release/net*/osx-x64/publish/consensus
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+    - id: scoop-file-update
+      name: scoop file version update
+      shell: pwsh
+      run: |
+        ./updatescoop.ps1 -Version ${{ steps.get_version.outputs.MajorMinorPatch  }}
+
+    - uses: stefanzweifel/git-auto-commit-action@v5
+      name: Commit new scoop file
+      with:
+        commit_message: Update scoop file to version ${{ steps.get_version.outputs.MajorMinorPatch  }}

--- a/gitversion.yml
+++ b/gitversion.yml
@@ -1,0 +1,5 @@
+branches:
+  # Use the Git tag for releases, e.g. v1.2.3 (it needs to be in Major.Minor.Patch format)
+  main:
+    increment: None
+

--- a/src/ConsensusApp/ConsensusApp/ConsensusApp.csproj
+++ b/src/ConsensusApp/ConsensusApp/ConsensusApp.csproj
@@ -2,6 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
+    <AssemblyName>consensus</AssemblyName>
     <TargetFramework>net9.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>

--- a/updatescoop.ps1
+++ b/updatescoop.ps1
@@ -1,0 +1,30 @@
+param(
+        [Parameter(Mandatory=$true)]
+        [String]
+        $version
+)
+
+$search = "*publish/consensus.exe"
+$consensusFile = Get-ChildItem -Path "./bin/Release/" -Force -Recurse -File | Where-Object { $_.FullName -like $search }
+$filePath = $consensusFile[0].FullName
+
+Write-Output "File found: $filePath, getting hash..."
+$hash = (Get-FileHash -Path $filePath -Algorithm SHA256).Hash
+Write-Output "Hash: $hash"
+
+Write-Output "Creating consensus.json for version $version..."
+Write-Output "{"
+Write-Output "  \"version\": \"$version\"," 
+Write-Output "  \"architecture\": {"
+Write-Output "      \"64bit\": {"
+Write-Output "          \"url\": \"https://github.com/yetanotherchris/consensus/releases/download/v$version/consensus.exe\"," 
+Write-Output "          \"bin\": ["
+Write-Output "              \"consensus.exe\""
+Write-Output "          ],"
+Write-Output "          \"hash\": \"$hash\""
+Write-Output "      }"
+Write-Output "  },"
+Write-Output "  \"homepage\": \"https://github.com/yetanotherchris/consensus\"," 
+Write-Output "  \"license\": \"MIT License\"," 
+Write-Output "  \"description\": \"A console app that aggregates multiple LLM responses\""
+Write-Output "}" | Out-File -FilePath "consensus.json" -Encoding utf8


### PR DESCRIPTION
## Summary
- add build-release workflow for GitHub Actions
- output executable named `consensus`
- include helper script to update scoop manifests
- add `gitversion.yml` config
- build macOS binaries in the workflow

## Testing
- `dotnet restore`
- `dotnet build -c Release`
- `dotnet test -c Release --no-build --verbosity normal`


------
https://chatgpt.com/codex/tasks/task_e_684617763ce4832f84f3baa7c14ee8f3