### PR TITLE
Add OpenAI-compatible endpoint

### DIFF
--- a/src/Consensus.Api/OpenAIRequest.cs
+++ b/src/Consensus.Api/OpenAIRequest.cs
@@ -1,0 +1,13 @@
+using System.Collections.Generic;
+using System.Text.Json.Serialization;
+
+namespace Consensus.Api;
+
+public sealed record OpenAIChatMessage(
+    [property: JsonPropertyName("role")] string Role,
+    [property: JsonPropertyName("content")] string Content);
+
+public sealed record OpenAIChatRequest(
+    [property: JsonPropertyName("model")] string Model,
+    [property: JsonPropertyName("messages")] List<OpenAIChatMessage> Messages,
+    [property: JsonPropertyName("stream")] bool Stream = false);

--- a/src/Consensus.Api/Program.cs
+++ b/src/Consensus.Api/Program.cs
@@ -114,6 +114,101 @@ app.MapPost("/consensus/stream", async (ConsensusRequest request, HttpResponse r
     .WithSummary("Streams each model's response in OpenAI format.")
     .WithOpenApi();
 
+app.MapPost("/v1/chat/completions", async (HttpRequest httpRequest, HttpResponse response, OpenAIChatRequest request) =>
+{
+    var auth = httpRequest.Headers["Authorization"].FirstOrDefault();
+    var apiKey = string.Empty;
+    if (!string.IsNullOrEmpty(auth) && auth.StartsWith("Bearer "))
+    {
+        apiKey = auth.Substring("Bearer ".Length).Trim();
+    }
+    if (string.IsNullOrEmpty(apiKey))
+    {
+        apiKey = Environment.GetEnvironmentVariable("OPENROUTER_API_KEY") ?? string.Empty;
+    }
+
+    var models = request.Model.Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
+    var prompt = request.Messages.LastOrDefault()?.Content ?? string.Empty;
+
+    var console = new ApiConsoleService();
+    var client = new OpenRouterClient(apiKey);
+    var processor = new ConsensusProcessor(client, console, NullLogger<ConsensusProcessor>.Instance);
+
+    if (!request.Stream)
+    {
+        var result = await processor.RunAsync(prompt, models, Consensus.LogLevel.None);
+        var resp = new
+        {
+            id = Guid.NewGuid().ToString(),
+            choices = new[] { new { index = 0, message = new { role = "assistant", content = result.Answer }, finish_reason = "stop" } },
+            consensus_result = new ConsensusResponse(result.Path, result.Answer, result.ChangesSummary, result.LogPath)
+        };
+        response.ContentType = "application/json";
+        await response.WriteAsync(JsonSerializer.Serialize(resp));
+        return;
+    }
+
+    response.Headers.Add("Content-Type", "text/event-stream");
+    response.Headers.Add("Cache-Control", "no-cache");
+
+    ConsensusResponse? finalResponse = null;
+
+    var processing = Task.Run(async () =>
+    {
+        try
+        {
+            var result = await processor.RunAsync(prompt, models, Consensus.LogLevel.None);
+            finalResponse = new ConsensusResponse(result.Path, result.Answer, result.ChangesSummary, result.LogPath);
+        }
+        catch (Exception ex)
+        {
+            await console.Channel.Writer.WriteAsync($"ERROR:{ex.Message}");
+        }
+        finally
+        {
+            console.Channel.Writer.Complete();
+        }
+    });
+
+    await foreach (var message in console.Channel.Reader.ReadAllAsync())
+    {
+        if (message.StartsWith("ERROR:"))
+        {
+            var errorJson = JsonSerializer.Serialize(new { error = message.Substring(6) });
+            await response.WriteAsync($"data: {errorJson}\n\n");
+            await response.Body.FlushAsync();
+            break;
+        }
+
+        var chunk = new
+        {
+            choices = new[] { new { index = 0, delta = new { content = message }, finish_reason = (string?)null } }
+        };
+        var json = JsonSerializer.Serialize(chunk);
+        await response.WriteAsync($"data: {json}\n\n");
+        await response.Body.FlushAsync();
+    }
+
+    if (finalResponse is not null)
+    {
+        var finalJson = JsonSerializer.Serialize(new
+        {
+            choices = new[] { new { index = 0, delta = new { }, finish_reason = "stop" } },
+            consensus_result = finalResponse
+        });
+        await response.WriteAsync($"data: {finalJson}\n\n");
+        await response.Body.FlushAsync();
+    }
+
+    await response.WriteAsync("data: [DONE]\n\n");
+    await response.Body.FlushAsync();
+
+    await processing;
+})
+    .WithName("OpenAIChatCompletions")
+    .WithSummary("OpenAI-compatible chat completions endpoint.")
+    .WithOpenApi();
+
 app.MapGet("/log", (string path) =>
 {
     if (!File.Exists(path))


### PR DESCRIPTION
## Summary
- expose an `/v1/chat/completions` endpoint so Open WebUI can call Consensus as an OpenAI-style backend
- define `OpenAIChatRequest` and `OpenAIChatMessage`

## Testing
- `dotnet build`
- `dotnet test tests/Consensus.Tests/Consensus.Tests.csproj` *(fails: `RunAsync_TwoModels_UsesPreviousAnswerForSummary` and `RunAsync_WritesExpectedFiles`)*

------
https://chatgpt.com/codex/tasks/task_e_6847dd7313a8832fb17bdcac21da96c9