### PR TITLE
Update summary limit and API markdown output

### DIFF
--- a/src/Consensus.Api/ApiConsoleService.cs
+++ b/src/Consensus.Api/ApiConsoleService.cs
@@ -21,7 +21,8 @@ internal sealed class ApiConsoleService : IConsoleService
 
     public async Task StatusAsync<T>(string statusFormat, T arg, Func<Task> action)
     {
-        Channel.Writer.TryWrite(string.Format(statusFormat, arg));
+        var message = string.Format(statusFormat, arg);
+        Channel.Writer.TryWrite($"### {message}");
         await action();
     }
 }

--- a/src/Consensus.Console/Consensus.Console/Resources/ChangeSummarySystemPrompt.txt
+++ b/src/Consensus.Console/Consensus.Console/Resources/ChangeSummarySystemPrompt.txt
@@ -1,3 +1,4 @@
-Summarize the changes you made compared to the previous answer using bullet points where possible. 
-Also include bullet points for any pros and cons of the previous model's answer. 
+Summarize the changes you made compared to the previous answer using bullet points where possible.
+Also include bullet points for any pros and cons of the previous model's answer.
+Keep the entire summary to three short sentences at most.
 If there are no issues and you agree with the previous answer, reply with 'I agree.' Don't use any Markdown except for bullet lists.


### PR DESCRIPTION
## Summary
- keep change summaries short with at most three sentences
- send formatted markdown status messages when streaming from the API

## Testing
- `dotnet restore`
- `dotnet build`
- `dotnet test` *(fails: InternalLoggerException)*

------
https://chatgpt.com/codex/tasks/task_e_68481c69312c832faaac38e8828a84cb