### PR TITLE
Add template-based answer rendering

### DIFF
--- a/src/Consensus.Api/ApiConsoleService.cs
+++ b/src/Consensus.Api/ApiConsoleService.cs
@@ -14,7 +14,8 @@ internal sealed class ApiConsoleService : IConsoleService
 
     public T Prompt<T>(IPrompt<T> prompt) => throw new InvalidOperationException("Prompting not supported in API mode.");
 
-    public void MarkupLine(string markup) => Channel.Writer.TryWrite(markup);
+    public void MarkupLine(string markup)
+        => Channel.Writer.TryWrite(markup + "\n");
 
     public async Task StatusAsync(string status, Func<Task> action)
         => await StatusAsync<string>(status, default!, action);
@@ -22,7 +23,7 @@ internal sealed class ApiConsoleService : IConsoleService
     public async Task StatusAsync<T>(string statusFormat, T arg, Func<Task> action)
     {
         var message = string.Format(statusFormat, arg);
-        Channel.Writer.TryWrite($"### {message}");
+        Channel.Writer.TryWrite($"**{message}...**\n");
         await action();
     }
 }

--- a/src/Consensus.Console/Consensus.Console/Consensus.Console.csproj
+++ b/src/Consensus.Console/Consensus.Console/Consensus.Console.csproj
@@ -29,6 +29,7 @@
 
   <ItemGroup>
     <EmbeddedResource Include="Resources\*.txt" />
+    <EmbeddedResource Include="Resources\*.md" />
   </ItemGroup>
 
 </Project>

--- a/src/Consensus.Console/Consensus.Console/ConsensusProcessor.cs
+++ b/src/Consensus.Console/Consensus.Console/ConsensusProcessor.cs
@@ -104,10 +104,14 @@ internal sealed class ConsensusProcessor
 
         var path = Path.Combine(Directory.GetCurrentDirectory(), $"answer_{baseName}.md");
         var finalAnswer = ExtractRevisedAnswer(answer);
-        var fileContent = $"## Answer\n\n{finalAnswer}\n\n## Changes Summary\n\n{summary}\n";
+        var fileContent = TemplateEngine.Render(
+            Templates.AnswerTemplate,
+            new { FinalAnswer = finalAnswer, ChangesSummary = summary });
         await File.WriteAllTextAsync(path, fileContent);
 
-        return new(path, finalAnswer, summary, logPath == string.Empty ? null : logPath);
+        _console.MarkupLine(fileContent);
+
+        return new(path, fileContent, summary, logPath == string.Empty ? null : logPath);
     }
 
     private async Task<string> SummarizeChangesAsync(string model, string answer, string previousAnswer)

--- a/src/Consensus.Console/Consensus.Console/Resources/AnswerTemplate.md
+++ b/src/Consensus.Console/Consensus.Console/Resources/AnswerTemplate.md
@@ -1,0 +1,8 @@
+## Final Answer
+
+{{ FinalAnswer }}
+
+## Changes Summary
+
+{{ ChangesSummary }}
+

--- a/src/Consensus.Console/Consensus.Console/TemplateEngine.cs
+++ b/src/Consensus.Console/Consensus.Console/TemplateEngine.cs
@@ -1,0 +1,47 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text.RegularExpressions;
+
+namespace Consensus;
+
+internal static class TemplateEngine
+{
+    private static readonly Regex TokenRegex = new(@"\$?{{\s*(?<token>[\w\.]+)\s*}}", RegexOptions.Compiled);
+
+    public static string Render(string template, object values)
+    {
+        return TokenRegex.Replace(template, m =>
+        {
+            var token = m.Groups["token"].Value;
+            var value = GetValue(values, token.Split('.'));
+            return value?.ToString() ?? string.Empty;
+        });
+    }
+
+    private static object? GetValue(object obj, IReadOnlyList<string> parts)
+    {
+        object? current = obj;
+        foreach (var part in parts)
+        {
+            if (current is null)
+            {
+                return null;
+            }
+            if (current is IDictionary<string, object> dict)
+            {
+                dict.TryGetValue(part, out current);
+            }
+            else
+            {
+                var prop = current.GetType().GetProperty(part);
+                if (prop is null)
+                {
+                    return null;
+                }
+                current = prop.GetValue(current);
+            }
+        }
+        return current;
+    }
+}

--- a/src/Consensus.Console/Consensus.Console/Templates.cs
+++ b/src/Consensus.Console/Consensus.Console/Templates.cs
@@ -1,0 +1,7 @@
+namespace Consensus;
+
+internal static class Templates
+{
+    public static readonly string AnswerTemplate =
+        ResourceHelper.GetString("Consensus.Resources.AnswerTemplate.md");
+}

--- a/tests/Consensus.Tests/ConsensusAppProcessorTests.cs
+++ b/tests/Consensus.Tests/ConsensusAppProcessorTests.cs
@@ -39,7 +39,7 @@ public class ConsensusProcessorTests
             Assert.True(File.Exists(result.LogPath!));
 
             var answer = File.ReadAllText(result.Path);
-            Assert.Equal("## Answer\n\nAnswer1\n\n## Changes Summary\n\nFinal summary\n", answer);
+            Assert.Equal("## Final Answer\n\nAnswer1\n\n## Changes Summary\n\nFinal summary\n", answer);
             Assert.Equal(answer, result.Answer);
 
             var log = File.ReadAllText(result.LogPath!);
@@ -85,7 +85,7 @@ public class ConsensusProcessorTests
             Assert.Contains("Answer2", summaryCall[2].Content.First().Text);
 
             var answer = File.ReadAllText(result.Path);
-            Assert.Equal("## Answer\n\nAnswer2\n\n## Changes Summary\n\nFinal summary\n", answer);
+            Assert.Equal("## Final Answer\n\nAnswer2\n\n## Changes Summary\n\nFinal summary\n", answer);
             Assert.Equal(answer, result.Answer);
 
             var log = File.ReadAllText(result.LogPath!);
@@ -126,7 +126,7 @@ public class ConsensusProcessorTests
             Assert.Equal(3, stub.Requests.Count);
 
             var answer = File.ReadAllText(result.Path);
-            Assert.Equal("## Answer\n\nAnswer2\n\n## Changes Summary\n\nFinal summary\n", answer);
+            Assert.Equal("## Final Answer\n\nAnswer2\n\n## Changes Summary\n\nFinal summary\n", answer);
 
             var log = File.ReadAllText(result.LogPath!);
             var expectedLog = "# model2\nSummary2\n\nNo changes as it's the first response.\n\n### Change Summaries\n#### model2\nNo changes as it's the first response.\n\n";


### PR DESCRIPTION
## Summary
- implement simple TemplateEngine for {{ tokens }}
- load answer output from new template file
- embed template resources in csproj
- render final answer using template

## Testing
- `dotnet restore`
- `dotnet build`
- `dotnet test` *(fails: no output)*

------
https://chatgpt.com/codex/tasks/task_e_6848215d3b28832f91e3623ed1da7f68