### PR TITLE
Switch to Scriban templating engine

### DIFF
--- a/src/Consensus.Console/Consensus.Console/Consensus.Console.csproj
+++ b/src/Consensus.Console/Consensus.Console/Consensus.Console.csproj
@@ -16,6 +16,7 @@
     <PackageReference Include="Spectre.Console.Cli" Version="0.50.0" />
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="9.0.0" />
     <PackageReference Include="AngleSharp" Version="1.1.0" />
+    <PackageReference Include="Scriban" Version="6.0.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Consensus.Console/Consensus.Console/TemplateEngine.cs
+++ b/src/Consensus.Console/Consensus.Console/TemplateEngine.cs
@@ -1,47 +1,12 @@
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text.RegularExpressions;
+using Scriban;
 
 namespace Consensus;
 
 internal static class TemplateEngine
 {
-    private static readonly Regex TokenRegex = new(@"\$?{{\s*(?<token>[\w\.]+)\s*}}", RegexOptions.Compiled);
-
     public static string Render(string template, object values)
     {
-        return TokenRegex.Replace(template, m =>
-        {
-            var token = m.Groups["token"].Value;
-            var value = GetValue(values, token.Split('.'));
-            return value?.ToString() ?? string.Empty;
-        });
-    }
-
-    private static object? GetValue(object obj, IReadOnlyList<string> parts)
-    {
-        object? current = obj;
-        foreach (var part in parts)
-        {
-            if (current is null)
-            {
-                return null;
-            }
-            if (current is IDictionary<string, object> dict)
-            {
-                dict.TryGetValue(part, out current);
-            }
-            else
-            {
-                var prop = current.GetType().GetProperty(part);
-                if (prop is null)
-                {
-                    return null;
-                }
-                current = prop.GetValue(current);
-            }
-        }
-        return current;
+        var scribanTemplate = Template.Parse(template);
+        return scribanTemplate.Render(values, member => member.Name);
     }
 }


### PR DESCRIPTION
## Summary
- replace custom TemplateEngine with Scriban
- add Scriban package reference

## Testing
- `dotnet restore`
- `dotnet build --no-restore`
- `dotnet test`

------
https://chatgpt.com/codex/tasks/task_e_68482d832850832f96f05606d0ed3048