### PR TITLE
Add model summary and query templates

### DIFF
--- a/src/Consensus.Api/ApiConsoleService.cs
+++ b/src/Consensus.Api/ApiConsoleService.cs
@@ -3,6 +3,7 @@ using System.Threading.Channels;
 using System.Threading.Tasks;
 using Spectre.Console;
 using Consensus.Console;
+using Consensus;
 
 namespace Consensus.Api;
 
@@ -22,8 +23,10 @@ internal sealed class ApiConsoleService : IConsoleService
 
     public async Task StatusAsync<T>(string statusFormat, T arg, Func<Task> action)
     {
-        var message = string.Format(statusFormat, arg);
-        Channel.Writer.TryWrite($"**{message}...**\n");
+        var markup = TemplateEngine.Render(
+            Templates.QueryingTemplate,
+            new { Model = arg });
+        Channel.Writer.TryWrite(markup + "\n");
         await action();
     }
 }

--- a/src/Consensus.Console/Consensus.Console/ConsensusProcessor.cs
+++ b/src/Consensus.Console/Consensus.Console/ConsensusProcessor.cs
@@ -63,7 +63,10 @@ internal sealed class ConsensusProcessor
                 var summaryText = firstModel
                     ? result.InitialSummary ?? ResponseParser.GetInitialResponseSummary(result.Answer)
                     : result.ChangeSummary;
-                _console.MarkupLine(summaryText);
+                var summaryMarkup = TemplateEngine.Render(
+                    Templates.ModelSummaryTemplate,
+                    new { ModelSummary = summaryText, Model = result.Model });
+                _console.MarkupLine(summaryMarkup);
             }
 
             if (firstModel)
@@ -106,7 +109,8 @@ internal sealed class ConsensusProcessor
         var finalAnswer = ExtractRevisedAnswer(answer);
         var fileContent = TemplateEngine.Render(
             Templates.AnswerTemplate,
-            new { FinalAnswer = finalAnswer, ChangesSummary = summary });
+            new { FinalAnswer = finalAnswer, ChangesSummary = summary })
+            .TrimEnd() + "\n";
         await File.WriteAllTextAsync(path, fileContent);
 
         _console.MarkupLine(fileContent);

--- a/src/Consensus.Console/Consensus.Console/Resources/ModelSummaryTemplate.md
+++ b/src/Consensus.Console/Consensus.Console/Resources/ModelSummaryTemplate.md
@@ -1,0 +1,3 @@
+{{ ModelSummary }}
+
+---

--- a/src/Consensus.Console/Consensus.Console/Resources/QueryingTemplate.md
+++ b/src/Consensus.Console/Consensus.Console/Resources/QueryingTemplate.md
@@ -1,0 +1,1 @@
+**Querying {{ Model }}...**

--- a/src/Consensus.Console/Consensus.Console/Templates.cs
+++ b/src/Consensus.Console/Consensus.Console/Templates.cs
@@ -2,6 +2,12 @@ namespace Consensus;
 
 internal static class Templates
 {
+    public static readonly string QueryingTemplate =
+        ResourceHelper.GetString("Consensus.Resources.QueryingTemplate.md");
+
+    public static readonly string ModelSummaryTemplate =
+        ResourceHelper.GetString("Consensus.Resources.ModelSummaryTemplate.md");
+
     public static readonly string AnswerTemplate =
         ResourceHelper.GetString("Consensus.Resources.AnswerTemplate.md");
 }


### PR DESCRIPTION
## Summary
- support new `QueryingTemplate` and `ModelSummaryTemplate`
- use query template in `ApiConsoleService`
- use model summary template when printing summaries
- ensure final answers have a consistent newline
- embed templates as resources

## Testing
- `dotnet build`
- `dotnet test tests/Consensus.Tests/Consensus.Tests.csproj -v minimal`

------
https://chatgpt.com/codex/tasks/task_e_684832267dec832fba532a7601752a51