### PR TITLE
Use template for model responses

### DIFF
--- a/src/Consensus.Core/ConsensusProcessor.cs
+++ b/src/Consensus.Core/ConsensusProcessor.cs
@@ -54,7 +54,15 @@ internal sealed class ConsensusProcessor
             results.Add(result);
             if (outputAnswers)
             {
-                _console.MarkupLine(ResponseParser.GetRevisedAnswer(answer));
+                var markup = TemplateEngine.Render(
+                    Templates.ResponseTemplate,
+                    new
+                    {
+                        Model = result.Model,
+                        Answer = ResponseParser.GetRevisedAnswer(result.Answer),
+                        ChangeSummary = result.ChangeSummary
+                    });
+                _console.MarkupLine(markup);
             }
             else
             {

--- a/src/Consensus.Core/Resources/ResponseTemplate.md
+++ b/src/Consensus.Core/Resources/ResponseTemplate.md
@@ -1,0 +1,5 @@
+### {{ Model }}
+
+{{ Answer }}
+
+**Changes:** {{ ChangeSummary }}

--- a/src/Consensus.Core/Templates.cs
+++ b/src/Consensus.Core/Templates.cs
@@ -10,4 +10,7 @@ internal static class Templates
 
     public static readonly string AnswerTemplate =
         ResourceHelper.GetString("Consensus.Core.Resources.AnswerTemplate.md");
+
+    public static readonly string ResponseTemplate =
+        ResourceHelper.GetString("Consensus.Core.Resources.ResponseTemplate.md");
 }


### PR DESCRIPTION
## Summary
- add `ResponseTemplate` resource
- use `ResponseTemplate` when printing each model answer

## Testing
- `dotnet build --no-restore`
- `dotnet test tests/Consensus.Tests/Consensus.Tests.csproj --no-build -v normal`

------
https://chatgpt.com/codex/tasks/task_e_684c9829c1fc832f93a21eb279e8d66c