### PR TITLE
Fix duplicate final output in API stream

### DIFF
--- a/src/Consensus.Api/Program.cs
+++ b/src/Consensus.Api/Program.cs
@@ -32,7 +32,7 @@ app.MapPost("/consensus", async (ConsensusRequest request) =>
         _ => Consensus.Core.LogLevel.None
     };
 
-    var result = await processor.RunAsync(request.Prompt, request.Models, logLevel);
+    var result = await processor.RunAsync(request.Prompt, request.Models, logLevel, outputFinalAnswer: false);
     return new ConsensusResponse(result.Path, result.Answer, result.ChangesSummary, result.LogPath);
 })
     .WithName("CreateConsensus")
@@ -62,7 +62,7 @@ app.MapPost("/consensus/stream", async (ConsensusRequest request, HttpResponse r
     {
         try
         {
-            var result = await processor.RunAsync(request.Prompt, request.Models, logLevel);
+            var result = await processor.RunAsync(request.Prompt, request.Models, logLevel, outputFinalAnswer: false);
             finalResponse = new ConsensusResponse(result.Path, result.Answer, result.ChangesSummary, result.LogPath);
         }
         catch (Exception ex)
@@ -136,7 +136,7 @@ app.MapPost("/v1/chat/completions", async (HttpRequest httpRequest, HttpResponse
 
     if (!request.Stream)
     {
-        var result = await processor.RunAsync(prompt, models, Consensus.Core.LogLevel.None);
+        var result = await processor.RunAsync(prompt, models, Consensus.Core.LogLevel.None, outputFinalAnswer: false);
         var resp = new
         {
             id = Guid.NewGuid().ToString(),
@@ -157,7 +157,7 @@ app.MapPost("/v1/chat/completions", async (HttpRequest httpRequest, HttpResponse
     {
         try
         {
-        var result = await processor.RunAsync(prompt, models, Consensus.Core.LogLevel.None, outputAnswers: false, logAnswers: false);
+        var result = await processor.RunAsync(prompt, models, Consensus.Core.LogLevel.None, outputAnswers: false, logAnswers: false, outputFinalAnswer: false);
             finalResponse = new ConsensusResponse(result.Path, result.Answer, result.ChangesSummary, result.LogPath);
         }
         catch (Exception ex)

--- a/src/Consensus.Core/ConsensusProcessor.cs
+++ b/src/Consensus.Core/ConsensusProcessor.cs
@@ -21,7 +21,7 @@ internal sealed class ConsensusProcessor
         _logger = logger;
     }
 
-    public async Task<ConsensusResult> RunAsync(string prompt, IReadOnlyList<string> models, LogLevel logLevel, bool outputAnswers = true, bool logAnswers = false)
+    public async Task<ConsensusResult> RunAsync(string prompt, IReadOnlyList<string> models, LogLevel logLevel, bool outputAnswers = true, bool logAnswers = false, bool outputFinalAnswer = true)
     {
         string answer = prompt;
         string previousModel = string.Empty;
@@ -119,7 +119,10 @@ internal sealed class ConsensusProcessor
             .TrimEnd() + "\n";
         await File.WriteAllTextAsync(path, fileContent);
 
-        _console.MarkupLine(fileContent);
+        if (outputFinalAnswer)
+        {
+            _console.MarkupLine(fileContent);
+        }
 
         return new(path, fileContent, summary, logPath == string.Empty ? null : logPath);
     }


### PR DESCRIPTION
## Summary
- stop sending final answer to the API channel
- allow callers to disable outputting the final answer
- update API endpoints to use the new option

## Testing
- `dotnet build --no-restore --verbosity minimal`
- `dotnet test --no-build --verbosity minimal`


------
https://chatgpt.com/codex/tasks/task_e_684cac41da20832f9fe1938c3a87295e