### PR TITLE
Fix ResourceHelper assembly lookup

### DIFF
--- a/src/Consensus.Core/ResourceHelper.cs
+++ b/src/Consensus.Core/ResourceHelper.cs
@@ -1,14 +1,16 @@
 using System;
 using System.IO;
 using System.Reflection;
+using System.Runtime.CompilerServices;
 
 namespace Consensus.Core;
 
 internal static class ResourceHelper
 {
+    [MethodImpl(MethodImplOptions.NoInlining)]
     public static string GetString(string resourceName)
     {
-        var assembly = Assembly.GetExecutingAssembly();
+        var assembly = Assembly.GetCallingAssembly();
         using var stream = assembly.GetManifestResourceStream(resourceName);
         if (stream is null)
         {


### PR DESCRIPTION
## Summary
- ensure ResourceHelper loads resources from the calling assembly

## Testing
- `dotnet restore`
- `dotnet build --no-restore`
- `dotnet test tests/Consensus.Tests/Consensus.Tests.csproj -v d`

------
https://chatgpt.com/codex/tasks/task_e_684d590578c8832fb90d004bf602c560