### PR TITLE
Add initial answer variable

### DIFF
--- a/src/Consensus.Api/ApiTemplates.cs
+++ b/src/Consensus.Api/ApiTemplates.cs
@@ -6,6 +6,7 @@ internal sealed class ApiTemplates : ITemplate
 {
     public string QueryingTemplate => ResourceHelper.GetString("Consensus.Api.Resources.QueryingTemplate.md");
     public string ModelSummaryTemplate => ResourceHelper.GetString("Consensus.Api.Resources.ModelSummaryTemplate.md");
+    public string InitialAnswerTemplate => ResourceHelper.GetString("Consensus.Api.Resources.InitialAnswerTemplate.md");
     public string AnswerTemplate => ResourceHelper.GetString("Consensus.Api.Resources.AnswerTemplate.md");
     public string ResponseTemplate => ResourceHelper.GetString("Consensus.Api.Resources.ResponseTemplate.md");
 }

--- a/src/Consensus.Api/Resources/InitialAnswerTemplate.md
+++ b/src/Consensus.Api/Resources/InitialAnswerTemplate.md
@@ -1,0 +1,2 @@
+**✅ Initial answer generated.**
+{{ InitialAnswer }}

--- a/src/Consensus.Console/ConsoleTemplates.cs
+++ b/src/Consensus.Console/ConsoleTemplates.cs
@@ -6,6 +6,7 @@ internal sealed class ConsoleTemplates : ITemplate
 {
     public string QueryingTemplate => ResourceHelper.GetString("Consensus.Console.Resources.QueryingTemplate.md");
     public string ModelSummaryTemplate => ResourceHelper.GetString("Consensus.Console.Resources.ModelSummaryTemplate.md");
+    public string InitialAnswerTemplate => ResourceHelper.GetString("Consensus.Console.Resources.InitialAnswerTemplate.md");
     public string AnswerTemplate => ResourceHelper.GetString("Consensus.Console.Resources.AnswerTemplate.md");
     public string ResponseTemplate => ResourceHelper.GetString("Consensus.Console.Resources.ResponseTemplate.md");
 }

--- a/src/Consensus.Console/Resources/InitialAnswerTemplate.md
+++ b/src/Consensus.Console/Resources/InitialAnswerTemplate.md
@@ -1,0 +1,2 @@
+**✅ Initial answer generated.**
+{{ InitialAnswer }}

--- a/src/Consensus.Core/ConsensusProcessor.cs
+++ b/src/Consensus.Core/ConsensusProcessor.cs
@@ -77,7 +77,14 @@ internal sealed class ConsensusProcessor
 
             if (firstModel)
             {
-                _console.MarkupLine("Initial answer generated.");
+                var initialMarkup = TemplateEngine.Render(
+                    _console.Templates.InitialAnswerTemplate,
+                    new
+                    {
+                        Model = result.Model,
+                        InitialAnswer = ResponseParser.GetInitialResponse(result.Answer)
+                    });
+                _console.MarkupLine(initialMarkup);
                 var initialSummary = result.InitialSummary ?? ResponseParser.GetInitialResponseSummary(result.Answer);
                 _logger.LogInformation("\n[bold]{Model} answer summary:[/]\n- {Summary}\n", result.Model, initialSummary);
             }

--- a/src/Consensus.Core/ITemplate.cs
+++ b/src/Consensus.Core/ITemplate.cs
@@ -4,6 +4,7 @@ public interface ITemplate
 {
     string QueryingTemplate { get; }
     string ModelSummaryTemplate { get; }
+    string InitialAnswerTemplate { get; }
     string AnswerTemplate { get; }
     string ResponseTemplate { get; }
 }

--- a/src/Consensus.Core/Resources/InitialAnswerTemplate.md
+++ b/src/Consensus.Core/Resources/InitialAnswerTemplate.md
@@ -1,0 +1,2 @@
+**✅ Initial answer generated.**
+{{ InitialAnswer }}

--- a/tests/Consensus.Tests/ConsensusAppProcessorTests.cs
+++ b/tests/Consensus.Tests/ConsensusAppProcessorTests.cs
@@ -154,6 +154,7 @@ public class ConsensusProcessorTests
     {
         public string QueryingTemplate => "**⏳ Querying {{ Model }}...**";
         public string ModelSummaryTemplate => "{{ ModelSummary }}\n\n---";
+        public string InitialAnswerTemplate => "Initial answer generated. {{ InitialAnswer }}";
         public string AnswerTemplate => "## 📗Final Answer\n{{FinalAnswer}}\n\n## Summary of all the changes made\n{{ChangesSummary}}";
         public string ResponseTemplate => "### {{ Model }}\n\n{{ Answer }}\n\n**📖 Changes:**\n{{ ChangeSummary }}\n\n---";
     }


### PR DESCRIPTION
## Summary
- append `{{ InitialAnswer }}` placeholder to the initial answer template across console, API and tests
- render the first model's response as `InitialAnswer` in `ConsensusProcessor`

## Testing
- `dotnet restore`
- `dotnet build --no-restore`
- `dotnet test tests/Consensus.Tests/Consensus.Tests.csproj -v n`


------
https://chatgpt.com/codex/tasks/task_e_684d67e6ad38832f82cd9e9a73852451