### PR TITLE
Restrict consensus skill to explicit user requests

### DIFF
--- a/SKILL.md
+++ b/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: consensus-review
-description: Orchestrates a multi-model panel review using the prompt templates from this Consensus repository. Discovers all agents prefixed with "consensus-subagent-" from opencode.jsonc, sends structured divergent prompts to each, synthesizes their responses, and renders output in the Consensus markdown format. Use when a user asks for a deep review, multi-perspective analysis, or panel evaluation of any document or code.
+description: Orchestrates a multi-model panel review using the prompt templates from this Consensus repository. Discovers all agents prefixed with "consensus-subagent-" from opencode.jsonc, sends structured divergent prompts to each, synthesizes their responses, and renders output in the Consensus markdown format. Only use when the user explicitly requests it, for example by saying "using the consensus skill" or "run the consensus skill".
 model: openrouter/anthropic/claude-opus-4.7
 license: MIT
 ---


### PR DESCRIPTION
## Summary

Updated the `consensus-review` skill description to clarify that it should only be invoked when users explicitly request it, rather than being used automatically for any deep review or multi-perspective analysis request.

## Changes

- Modified the skill description in `SKILL.md` to specify explicit activation criteria
- Added examples of explicit requests: "using the consensus skill" or "run the consensus skill"
- This prevents the skill from being triggered by implicit user intent and ensures it's only used when deliberately requested

## Rationale

This change improves the user experience by preventing unintended skill invocations. The consensus skill orchestrates a multi-model panel review which may be resource-intensive or unnecessary for all review requests. By requiring explicit user activation, we ensure the skill is only used when the user specifically wants a consensus-based analysis.

https://claude.ai/code/session_01SfJNJTjbjmozECGJtuhGUj